### PR TITLE
Add NextAuth route handler for authentication endpoints

### DIFF
--- a/appfin/src/app/api/auth/[...nextauth]/route.ts
+++ b/appfin/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,7 @@
+import NextAuth from 'next-auth'
+
+import { authOptions } from '@/lib/auth'
+
+const handler = NextAuth(authOptions)
+
+export { handler as GET, handler as POST }


### PR DESCRIPTION
## Summary
- add the NextAuth API route so authentication requests are served instead of returning 404s

## Testing
- npm run lint *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f3be231f38832d911b23114377aa4a